### PR TITLE
HAS-35 Configuration set constants for Bifrost service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.projectlombok:lombok:1.18.36'
+    annotationProcessor('org.projectlombok:lombok:1.18.36')
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/src/main/java/com/heimdallauth/server/bifrost/SuppressionListEntry.java
+++ b/src/main/java/com/heimdallauth/server/bifrost/SuppressionListEntry.java
@@ -1,0 +1,14 @@
+package com.heimdallauth.server.bifrost;
+
+import com.heimdallauth.server.constants.SuppressionListEntryType;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SuppressionListEntry {
+    private SuppressionListEntryType type;
+    private String value;
+}

--- a/src/main/java/com/heimdallauth/server/constants/SmtpEncryption.java
+++ b/src/main/java/com/heimdallauth/server/constants/SmtpEncryption.java
@@ -1,0 +1,7 @@
+package com.heimdallauth.server.constants;
+
+public enum SmtpEncryption {
+    NONE,
+    SSL,
+    STARTTLS
+}

--- a/src/main/java/com/heimdallauth/server/constants/SuppressionListEntryType.java
+++ b/src/main/java/com/heimdallauth/server/constants/SuppressionListEntryType.java
@@ -1,0 +1,7 @@
+package com.heimdallauth.server.constants;
+
+public enum SuppressionListEntryType {
+    EMAIL,
+    EMAIL_DOMAIN
+
+}

--- a/src/main/java/com/heimdallauth/server/utils/HeimdallMetadata.java
+++ b/src/main/java/com/heimdallauth/server/utils/HeimdallMetadata.java
@@ -1,0 +1,13 @@
+package com.heimdallauth.server.utils;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class HeimdallMetadata {
+    private String key;
+    private String value;
+}


### PR DESCRIPTION
This pull request introduces new classes and enums to the `com.heimdallauth.server` package, adding support for suppression list entries and SMTP encryption types. The most important changes include the addition of `SuppressionListEntry` and `HeimdallMetadata` classes, as well as the `SmtpEncryption` and `SuppressionListEntryType` enums.

New classes:

* [`src/main/java/com/heimdallauth/server/bifrost/SuppressionListEntry.java`](diffhunk://#diff-262755e39e82eaddd7604e54244527bf8505e7a1636b965f4b10cf5d25223202R1-R14): Added `SuppressionListEntry` class with fields for `type` and `value`, and annotations for builder pattern and getters/setters.
* [`src/main/java/com/heimdallauth/server/utils/HeimdallMetadata.java`](diffhunk://#diff-f3ec4c342981b19c920b84cc46503407b66cd81dfb03c15a80beb09e57fdf7afR1-R13): Added `HeimdallMetadata` class with fields for `key` and `value`, and annotations for builder pattern and getters/setters.

New enums:

* [`src/main/java/com/heimdallauth/server/constants/SmtpEncryption.java`](diffhunk://#diff-836a4f0bc2791986321feefc6e05e8fefcea07ead007030377042a43c160c55fR1-R7): Added `SmtpEncryption` enum with values `NONE`, `SSL`, and `STARTTLS`.
* [`src/main/java/com/heimdallauth/server/constants/SuppressionListEntryType.java`](diffhunk://#diff-6c146fb891d64a48d39f13a24a162fc281baec0e345e6de7901973160ffac167R1-R7): Added `SuppressionListEntryType` enum with values `EMAIL` and `EMAIL_DOMAIN`.