### PR TITLE
HAS-36 Changes for Metadata Utility to provide required methods for Heimdall Metadata

### DIFF
--- a/src/main/java/com/heimdallauth/server/utils/MetadataUtils.java
+++ b/src/main/java/com/heimdallauth/server/utils/MetadataUtils.java
@@ -1,0 +1,15 @@
+package com.heimdallauth.server.utils;
+
+import java.time.Instant;
+import java.util.List;
+
+public class MetadataUtils {
+    private static final String CREATION_TIMESTAMP_KEY = "creationTimestamp";
+    private static final String UPDATE_TIMESTAMP_KEY = "updateTimestamp";
+    public static List<HeimdallMetadata> getCreationAndUpdateTimestamps(){
+        return List.of(
+          HeimdallMetadata.builder().key(CREATION_TIMESTAMP_KEY).value(Instant.now().toString()).build(),
+            HeimdallMetadata.builder().key(UPDATE_TIMESTAMP_KEY).value(Instant.now().toString()).build()
+        );
+    }
+}

--- a/src/main/java/com/heimdallauth/server/utils/MetadataUtils.java
+++ b/src/main/java/com/heimdallauth/server/utils/MetadataUtils.java
@@ -2,6 +2,8 @@ package com.heimdallauth.server.utils;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class MetadataUtils {
     private static final String CREATION_TIMESTAMP_KEY = "creationTimestamp";
@@ -11,5 +13,19 @@ public class MetadataUtils {
           HeimdallMetadata.builder().key(CREATION_TIMESTAMP_KEY).value(Instant.now().toString()).build(),
             HeimdallMetadata.builder().key(UPDATE_TIMESTAMP_KEY).value(Instant.now().toString()).build()
         );
+    }
+    public static List<HeimdallMetadata> createAndAddMetadataToExistingMetadata(List<HeimdallMetadata> metadata, String key, String value){
+        return Stream.concat(metadata.stream(), Stream.of(HeimdallMetadata.builder().key(key).value(value).build()))
+                     .collect(Collectors.toList());
+    }
+    public static List<HeimdallMetadata> updateTimestamp(List<HeimdallMetadata> metadata){
+        return metadata.stream()
+                .map(m -> {
+                    if(m.getKey().equals(UPDATE_TIMESTAMP_KEY)){
+                        return HeimdallMetadata.builder().key(m.getKey()).value(Instant.now().toString()).build();
+                    }
+                    return m;
+                })
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
This pull request adds a new utility class `MetadataUtils` to the `src/main/java/com/heimdallauth/server/utils/` directory. The class provides methods for handling metadata related to creation and update timestamps.

The most important changes include:

* Added `MetadataUtils` class with methods for generating creation and update timestamps, adding new metadata to existing metadata, and updating the timestamp of existing metadata. (`src/main/java/com/heimdallauth/server/utils/MetadataUtils.java`)