### PR TITLE
HAS-31 Changes for Configurable JavaMailSender

### DIFF
--- a/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
+++ b/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
@@ -1,0 +1,13 @@
+package com.heimdallauth.server.dto.bifrost;
+
+import com.heimdallauth.server.models.bifrost.EmailDestination;
+import com.heimdallauth.server.models.bifrost.EmailTemplateContent;
+
+import java.util.List;
+
+public record SendEmailDTO(
+        EmailDestination destination,
+        EmailTemplateContent content,
+        List<String> replyToEmails
+) {
+}

--- a/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
+++ b/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
@@ -4,8 +4,10 @@ import com.heimdallauth.server.models.bifrost.EmailDestination;
 import com.heimdallauth.server.models.bifrost.EmailTemplateContent;
 
 import java.util.List;
+import java.util.UUID;
 
 public record SendEmailDTO(
+        UUID configurationSetId,
         EmailDestination destination,
         EmailTemplateContent content,
         List<String> replyToEmails

--- a/src/main/java/com/heimdallauth/server/models/bifrost/EmailDestination.java
+++ b/src/main/java/com/heimdallauth/server/models/bifrost/EmailDestination.java
@@ -1,0 +1,10 @@
+package com.heimdallauth.server.models.bifrost;
+
+import java.util.List;
+
+public record EmailDestination(
+        List<String> toDestinationEmailAddress,
+        List<String> ccDestinationEmailAddress,
+        List<String> bccDestinationEmailAddress
+) {
+}


### PR DESCRIPTION
This pull request introduces new data transfer objects (DTOs) for handling email operations in the `bifrost` package. The changes include the addition of two new classes: `SendEmailDTO` and `EmailDestination`.

New DTOs for email operations:

* [`src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java`](diffhunk://#diff-0314d7dfddbbd0114a45b336c720a776c65a5d1ffcb9c2564700cebd98308bf0R1-R15): Added `SendEmailDTO` class to encapsulate email sending details, including configuration set ID, destination, content, and reply-to emails.
* [`src/main/java/com/heimdallauth/server/models/bifrost/EmailDestination.java`](diffhunk://#diff-eb6566456bd1d994694ec16f7db8faf826dac462acae8430f0e68f2fce743e7eR1-R10): Added `EmailDestination` class to represent email destination details, including to, cc, and bcc email addresses.