### PR TITLE
HAS-47 Changes for DTO to update the SendEmail request

### DIFF
--- a/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
+++ b/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 public record SendEmailDTO(
         UUID configurationSetId,
         EmailDestination destination,
-        String templateId,
+        UUID templateId,
         EmailContent content,
         EmailContext context,
         List<String> replyToEmails

--- a/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
+++ b/src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 public record SendEmailDTO(
         UUID configurationSetId,
         EmailDestination destination,
+        String templateId,
         EmailContent content,
         EmailContext context,
         List<String> replyToEmails


### PR DESCRIPTION
This pull request includes a change to the `SendEmailDTO` class to add a new field for specifying the email template ID.

* [`src/main/java/com/heimdallauth/server/dto/bifrost/SendEmailDTO.java`](diffhunk://#diff-0314d7dfddbbd0114a45b336c720a776c65a5d1ffcb9c2564700cebd98308bf0R13): Added a new field `UUID templateId` to the `SendEmailDTO` record.